### PR TITLE
Add login form to nav bar

### DIFF
--- a/app/assets/javascripts/coworfing/coworfing.js.coffee
+++ b/app/assets/javascripts/coworfing/coworfing.js.coffee
@@ -27,7 +27,12 @@ jQuery ->
   $('#back-to-top').click ()->
     $('body,html').animate({scrollTop:0},600)
 
-
   # fancybox
   $(".fancybox").fancybox()
+  
+  # show login box on nav
+  $(".navbar-loginbox").click ()->
+    $('.navbar-login').fadeIn()
+    $('#navbar-login-email').focus()
+    return false
 

--- a/app/assets/stylesheets/theme_override.css.sass
+++ b/app/assets/stylesheets/theme_override.css.sass
@@ -76,6 +76,26 @@ h3
 .invite
   margin-top: 30px
 
+.navbar-login
+  background: #f6f6f6
+  border-radius: 0 0 5px 5px
+  border-left: 1px solid #999
+  border-right: 1px solid #999
+  border-bottom: 1px solid #999
+  padding: 10px
+  position: absolute
+  right: 0
+  top: -20
+  z-index: 100
+
+.navbar-input
+  float: left
+  margin: 0 0 10px 0 
+
+.navbar-login-checkbox
+  margin: 5px 30px 20px 0
+  width: 120px
+
 /** FIGCAPTION **/
 
 figcaption

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -22,7 +22,16 @@
         = t('navbar.people')
 
     - unless user_signed_in?
-      %li= link_to t('login'), new_user_session_path
+      %li
+        = link_to t('login'), new_user_session_path, class: 'navbar-loginbox'
+        = simple_form_for(:user, :url => session_path(:user), html: { class: 'navbar-login hidden' }) do |f|
+          = f.input :email, placeholder: 'Email', label: false, input_html: { id: 'navbar-login-email', class: 'navbar-input' }
+          = f.input :password, placeholder: 'Password', label: false, input_html: { id: 'navbar-login-password', class: 'navbar-input' }
+          %div.clr
+            = f.input :remember_me, as: :boolean, wrapper_html: { class: 'navbar-login-checkbox fl' }, label_html: { class: 'fr'}
+            = f.submit "Sign in", class: 'btn btn-primary'
+          %div.clr
+            = link_to "Forgot your password?", new_password_path(:user)
 
     - else
       %li.dropdown.current_person


### PR DESCRIPTION
When user clicks on "Login" on nav menu, a small form will appear that will allow the user to enter their email & password and log into the site.

By default the mini login form will not show.

![coworflogin](https://f.cloud.github.com/assets/743877/558811/550534f0-c432-11e2-870a-5f630ea5d2c1.png)

(That yellow border you see is just an artefact of loading on Opera)
